### PR TITLE
Allow upstream consumers to override build settings

### DIFF
--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -253,6 +253,7 @@
   <ItemGroup>
     <None Include="mono.snk" />
   </ItemGroup>
+  <Import Project="Mono.Cecil.Settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Mono.Cecil.settings
+++ b/Mono.Cecil.settings
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This optional import allows products that distribute Cecil to tweak settings that will affect its 
+       build, without having to fork the project unnecessarily. The Mono.Cecil.overrides file is a plain 
+       MSBuild file with additional properties, and can exist anywhere upwards from the current Cecil repo 
+       clone path, making it very flexible even if the project is submoduled. 
+  -->
+  <PropertyGroup>
+    <CecilOverrides Condition="'$(CecilOverrides)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Mono.Cecil.overrides))\Mono.Cecil.overrides</CecilOverrides>
+  </PropertyGroup>  
+  <Import Project="$(CecilOverrides)" Condition="Exists($(CecilOverrides))" />
+  
+  <!-- This is an example of a custom override file -->
+  <!--
+	<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	  <PropertyGroup>
+		<AssemblyName>$(AssemblyName.Replace('Mono', 'MyCompany'))</AssemblyName>
+		<AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)MyCompany.snk</AssemblyOriginatorKeyFile>
+	  </PropertyGroup>
+		<ItemGroup>
+			<Compile Include="$(MSBuildThisFileDirectory)MyCompany.AssemblyInfo.cs" />
+		</ItemGroup>
+	</Project>
+	
+	The additional AssemblyInfo.cs added to the Compile group provides the InternalsVisibleTo so that 
+	the Mdb/Pdb projects can compile successfully:
+	
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: InternalsVisibleTo ("MyCompany.Cecil.Pdb, PublicKey=....")]
+[assembly: InternalsVisibleTo ("MyCompany.Cecil.Mdb, PublicKey=...")]
+[assembly: InternalsVisibleTo ("MyCompany.Cecil.Rocks, PublicKey=...")]
+[assembly: InternalsVisibleTo ("MyCompany.Cecil.Tests, PublicKey=...")]	
+  -->
+</Project>

--- a/rocks/Mono.Cecil.Rocks.csproj
+++ b/rocks/Mono.Cecil.Rocks.csproj
@@ -118,6 +118,7 @@
       <Name>Mono.Cecil</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="..\Mono.Cecil.Settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/symbols/mdb/Mono.Cecil.Mdb.csproj
+++ b/symbols/mdb/Mono.Cecil.Mdb.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Mono.CompilerServices.SymbolWriter\SourceMethodBuilder.cs" />
     <Compile Include="Mono.CompilerServices.SymbolWriter\SymbolWriterImpl.cs" />
   </ItemGroup>
+  <Import Project="..\..\Mono.Cecil.Settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/symbols/pdb/Mono.Cecil.Pdb.csproj
+++ b/symbols/pdb/Mono.Cecil.Pdb.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Mono.Cecil.Pdb\SymDocumentWriter.cs" />
     <Compile Include="Mono.Cecil.Pdb\SymWriter.cs" />
   </ItemGroup>
+  <Import Project="..\..\Mono.Cecil.Settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Same as kzu's PR upstream (https://github.com/jbevain/cecil/pull/217) but we don't have the existing settings files, so simplifying it to our structure.

@alanmcgovern: want to merge? :)