### PR TITLE
Fixes settings for xbuild

### DIFF
--- a/Mono.Cecil.settings
+++ b/Mono.Cecil.settings
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <CecilOverrides Condition="'$(CecilOverrides)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Mono.Cecil.overrides))\Mono.Cecil.overrides</CecilOverrides>
   </PropertyGroup>  
-  <Import Project="$(CecilOverrides)" Condition="Exists($(CecilOverrides))" />
+  <Import Project="'$(CecilOverrides)'" Condition="Exists('$(CecilOverrides)')" />
   
   <!-- This is an example of a custom override file -->
   <!--


### PR DESCRIPTION
In MSBuild those properties are recognised, but xBuild requires them to be surrounded by colons.