### PR TITLE
Relocated settings so the overrides can get the AssemblyName

### DIFF
--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="Mono.Cecil.settings" />
   <PropertyGroup>
     <ProjectGuid>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</ProjectGuid>
     <RootNamespace>Mono.Cecil</RootNamespace>
@@ -139,5 +138,6 @@
     <Compile Include="Mono\Empty.cs" />
     <Compile Include="Mono\Funcs.cs" />
   </ItemGroup>
+  <Import Project="Mono.Cecil.settings" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/symbols/mdb/Mono.Cecil.Mdb.csproj
+++ b/symbols/mdb/Mono.Cecil.Mdb.csproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Mono.Cecil.settings" />
   <PropertyGroup>
     <ProjectGuid>{8559DD7F-A16F-46D0-A05A-9139FAEBA8FD}</ProjectGuid>
     <RootNamespace>Mono.Cecil.Mdb</RootNamespace>


### PR DESCRIPTION
@radekdoulik we need settings to happen after AssemblyName is defined, because we change the assembly name to avoid collitions with other versions of Mono.Cecil. That happens in Overrides, which is imported by cecil. Please review and ping me if you see anything wrong with this. I left it right after the first property group so the Configuration|Platforms will be at the correct position.

I also removed a warning in Cecil.Mdb that was happening because settings was defined twice.