### PR TITLE
Add missing HasParameters check inside MethodReference.ContainsGenericParameter

### DIFF
--- a/Mono.Cecil/MethodReference.cs
+++ b/Mono.Cecil/MethodReference.cs
@@ -122,6 +122,9 @@ namespace Mono.Cecil {
 				if (this.ReturnType.ContainsGenericParameter || base.ContainsGenericParameter)
 					return true;
 
+				if (!HasParameters)
+					return false;
+
 				var parameters = this.Parameters;
 
 				for (int i = 0; i < parameters.Count; i++)


### PR DESCRIPTION
Without this check a new, empty collection can be allocated and it's
whole and only purpose will be to iterate up to 0 (nop).

The check saves a small amount of memory (collections) and time.