### PR TITLE
[ppdb] Fix the encoding/decoding of empty parts in document names, th…

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -3750,7 +3750,9 @@ namespace Mono.Cecil {
 				if (i > 0 && separator != 0)
 					builder.Append (separator);
 
-				builder.Append (reader.ReadUTF8StringBlob (ReadCompressedUInt32 ()));
+				uint part = ReadCompressedUInt32 ();
+				if (part != 0)
+					builder.Append (reader.ReadUTF8StringBlob (part));
 			}
 
 			return builder.ToString ();

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -2507,10 +2507,13 @@ namespace Mono.Cecil {
 			}
 
 			signature.WriteByte ((byte) separator);
-
-			var parts = name.Split (new [] { separator }, StringSplitOptions.RemoveEmptyEntries);
-			for (int i = 0; i < parts.Length; i++)
-				signature.WriteCompressedUInt32 (GetUTF8StringBlobIndex (parts [i]));
+			var parts = name.Split (new [] { separator });
+			for (int i = 0; i < parts.Length; i++) {
+				if (parts [i] == String.Empty)
+					signature.WriteCompressedUInt32 (0);
+				else
+					signature.WriteCompressedUInt32 (GetUTF8StringBlobIndex (parts [i]));
+			}
 
 			return signature;
 		}

--- a/Mono.Cecil/MethodReturnType.cs
+++ b/Mono.Cecil/MethodReturnType.cs
@@ -48,6 +48,11 @@ namespace Mono.Cecil {
 			set { Parameter.Attributes = value; }
 		}
 
+		public string Name {
+			get { return Parameter.Name; }
+			set { Parameter.Name = value; }
+		}
+
 		public bool HasCustomAttributes {
 			get { return parameter != null && parameter.HasCustomAttributes; }
 		}


### PR DESCRIPTION
…ey should be encoded as index 0. Also, empty parts should be retained during writing, since /foo/bar is encoded as <empty><foo><bar>.