### PR TITLE
Fix BaseAssemblyResolver.SearchDirectory.

### DIFF
--- a/Mono.Cecil.nuspec
+++ b/Mono.Cecil.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Mono.Cecil</id>
-    <version>0.10.0.0-beta1-v2</version>
+    <version>0.10.0.0-beta2</version>
     <title>Mono.Cecil</title>
     <authors>Jb Evain</authors>
     <owners>Jb Evain</owners>

--- a/ProjectInfo.cs
+++ b/ProjectInfo.cs
@@ -19,4 +19,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion ("0.10.0.0")]
 [assembly: AssemblyFileVersion ("0.10.0.0")]
-[assembly: AssemblyInformationalVersion ("0.10.0.0-beta1")]
+[assembly: AssemblyInformationalVersion ("0.10.0.0-beta2")]


### PR DESCRIPTION
Fix BaseAssemblyResolver.SearchDirectory to try both .exe and .dll when searching for an assembly.
This fixes a scenario when there is a native Foo.exe and a managed Foo.dll in the search directories.	
