### PR TITLE
[ImageWriter] zero stream length before writting

### DIFF
--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -110,6 +110,7 @@ namespace Mono.Cecil {
 
 			var writer = ImageWriter.CreateWriter (module, metadata, stream);
 
+			stream.value.SetLength (0);
 			writer.WriteImage ();
 
 			if (metadata.symbol_writer != null)


### PR DESCRIPTION
 - it fixes the case, where we have an assembly read with
   ReadWrite=true parameter, remove parts of it and write it
   back. before we ended with the new assembly file with the same size
   as the original, so it wasn't truncated

cherry-picked from upstream cecil to fix #53250