### PR TITLE
Don't stop looking for symbols if we can't load a native pdb symbol provider. Fixes #56808.

### DIFF
--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -735,8 +735,13 @@ namespace Mono.Cecil.Cil {
 			}
 
 			var mdb_file_name = Mixin.GetMdbFileName (fileName);
-			if (File.Exists (mdb_file_name))
-				return SymbolProvider.GetReaderProvider (SymbolKind.Mdb).GetSymbolReader (module, fileName);
+			if (File.Exists (mdb_file_name)) {
+				try {
+					return SymbolProvider.GetReaderProvider (SymbolKind.Mdb).GetSymbolReader (module, fileName);
+				} catch (TypeLoadException) {
+					// We might not include support for mdbs.
+				}
+			}
 
 			if (throw_if_no_symbol)
 				throw new FileNotFoundException (string.Format ("No symbol found for file: {0}", fileName));

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -723,10 +723,16 @@ namespace Mono.Cecil.Cil {
 
 			var pdb_file_name = Mixin.GetPdbFileName (fileName);
 
-			if (File.Exists (pdb_file_name))
-				return Mixin.IsPortablePdb (Mixin.GetPdbFileName (fileName))
-					? new PortablePdbReaderProvider ().GetSymbolReader (module, fileName)
-					: SymbolProvider.GetReaderProvider (SymbolKind.NativePdb).GetSymbolReader (module, fileName);
+			if (File.Exists (pdb_file_name)) {
+				if (Mixin.IsPortablePdb (Mixin.GetPdbFileName (fileName)))
+					return new PortablePdbReaderProvider ().GetSymbolReader (module, fileName);
+
+				try {
+					return SymbolProvider.GetReaderProvider (SymbolKind.NativePdb).GetSymbolReader (module, fileName);
+				} catch (TypeLoadException) {
+					// We might not include support for native pdbs.
+				}
+			}
 
 			var mdb_file_name = Mixin.GetMdbFileName (fileName);
 			if (File.Exists (mdb_file_name))


### PR DESCRIPTION
We might run into native pdbs, but we might not include support for native
pdbs, in which case we shouldn't stop looking for other debug symbols we might
be able to load (mdbs).

https://bugzilla.xamarin.com/show_bug.cgi?id=56808