### PR TITLE
fix reading scope start

### DIFF
--- a/Mono.Cecil.Cil/CodeReader.cs
+++ b/Mono.Cecil.Cil/CodeReader.cs
@@ -160,7 +160,8 @@ namespace Mono.Cecil.Cil {
 		void ReadScope (ScopeDebugInformation scope)
 		{
 			var start_instruction = GetInstruction (scope.Start.Offset);
-			scope.Start = new InstructionOffset (start_instruction);
+			if (start_instruction != null)
+				    scope.Start = new InstructionOffset (start_instruction);
 
 			var end_instruction = GetInstruction (scope.End.Offset);
 			scope.End = end_instruction != null


### PR DESCRIPTION
 - in case when the mdb file is out of sync, we might endup with
   start_instruction being null

 - it is regression introduced by
   7c8e0f767d7b2f652a430e4e26f1d98a20f9e125