### PR TITLE
If GetReaderProvider throws for any reason, we consider there's no sy…

### DIFF
--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -782,7 +782,7 @@ namespace Mono.Cecil.Cil {
 
 				try {
 					return SymbolProvider.GetReaderProvider (SymbolKind.NativePdb).GetSymbolReader (module, fileName);
-				} catch (TypeLoadException) {
+				} catch (Exception) {
 					// We might not include support for native pdbs.
 				}
 			}
@@ -791,7 +791,7 @@ namespace Mono.Cecil.Cil {
 			if (File.Exists (mdb_file_name)) {
 				try {
 					return SymbolProvider.GetReaderProvider (SymbolKind.Mdb).GetSymbolReader (module, fileName);
-				} catch (TypeLoadException) {
+				} catch (Exception) {
 					// We might not include support for mdbs.
 				}
 			}


### PR DESCRIPTION
…mbol for the assembly in the DefaultSymbolReader