### PR TITLE
Restored full path in filename property

### DIFF
--- a/Mono.Cecil.Cil/PortablePdb.cs
+++ b/Mono.Cecil.Cil/PortablePdb.cs
@@ -319,8 +319,6 @@ namespace Mono.Cecil.Cil {
 			buffer.WriteUInt32 (1);
 			// PDB Path
 			var filename = writer.BaseStream.GetFileName ();
-			if (!string.IsNullOrEmpty (filename))
-				filename = Path.GetFileName (filename);
 
 			buffer.WriteBytes (System.Text.Encoding.UTF8.GetBytes (filename));
 			buffer.WriteByte (0);


### PR DESCRIPTION
UWP uses the filename property to find the pdb file when debugging. Changing the value that's already in the dll to just the filename renders the debugger unable to find the pdb file, and UWP debugging then works with no symbols (meaning, no breakpoints and not pausing and stepping). The lines I removed seem intentional, though, so I'm opening this for discussion. This is at the moment affecting the XamlG task in Xamarin Forms, but it also probably affects other clients of Cecil like Fody. Android and iOS are not affected by this because the logic for finding the pdb in the mono debugger is slightly different than what it is in the .Net debugger.