### PR TITLE
Fix writing symbols when using deterministic mvids. The ppdb file embeds the guid of the corresponding assembly.

### DIFF
--- a/Mono.Cecil.Cil/PortablePdb.cs
+++ b/Mono.Cecil.Cil/PortablePdb.cs
@@ -276,6 +276,11 @@ namespace Mono.Cecil.Cil {
 			this.writer = writer;
 		}
 
+		public void PatchMvid (Guid guid)
+		{
+			writer.PatchMvid (guid);
+		}
+
 		public ISymbolReaderProvider GetReaderProvider ()
 		{
 			return new PortablePdbReaderProvider ();

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -126,6 +126,8 @@ namespace Mono.Cecil {
 					if (parameters.DeterministicMvid) {
 						module.Mvid = ComputeGuid (stream.value);
 						writer.PatchMvid (module.Mvid);
+						if (symbol_writer is PortablePdbWriter ppdb_writer)
+							ppdb_writer.PatchMvid (module.Mvid);
 					}
 				}
 			} finally {


### PR DESCRIPTION
Fixes https://github.com/jbevain/cecil/issues/583.