### PR TITLE
Update the version of Microsoft.NETFramework.ReferenceAssemblies.net40

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(MonoBuild)' != ''">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
Update the version of Microsoft.NETFramework.ReferenceAssemblies.net40 since is detected as a package downgrade and a failure in newer SDKs
See failures in:
https://github.com/mono/linker/pull/2156/checks?check_run_id=3119342202