### PR TITLE
Fix portable PDB stamp in CodeView header

### DIFF
--- a/Mono.Cecil.Cil/PortablePdb.cs
+++ b/Mono.Cecil.Cil/PortablePdb.cs
@@ -269,7 +269,7 @@ namespace Mono.Cecil.Cil {
 
 		internal byte [] pdb_checksum;
 		internal Guid pdb_id_guid;
-		internal uint pdb_id_age;
+		internal uint pdb_id_stamp;
 
 		bool IsEmbedded { get { return writer == null; } }
 
@@ -324,7 +324,7 @@ namespace Mono.Cecil.Cil {
 					MajorVersion = 256,
 					MinorVersion = 20557,
 					Type = ImageDebugType.CodeView,
-					TimeDateStamp = (int)module.timestamp,
+					TimeDateStamp = (int)pdb_id_stamp,
 				};
 
 				var buffer = new ByteBuffer ();
@@ -333,7 +333,7 @@ namespace Mono.Cecil.Cil {
 				// Module ID
 				buffer.WriteBytes (pdb_id_guid.ToByteArray ());
 				// PDB Age
-				buffer.WriteUInt32 (pdb_id_age);
+				buffer.WriteUInt32 (1);
 				// PDB Path
 				var fileName = writer.BaseStream.GetFileName ();
 				if (string.IsNullOrEmpty (fileName)) {
@@ -462,7 +462,7 @@ namespace Mono.Cecil.Cil {
 
 			var hashBytes = new ByteBuffer (pdb_checksum);
 			pdb_id_guid = new Guid (hashBytes.ReadBytes (16));
-			pdb_id_age = hashBytes.ReadUInt32 ();
+			pdb_id_stamp = hashBytes.ReadUInt32 ();
 		}
 
 		void WritePdbId ()
@@ -470,7 +470,7 @@ namespace Mono.Cecil.Cil {
 			// PDB ID is the first 20 bytes of the PdbHeap
 			writer.MoveToRVA (TextSegment.PdbHeap);
 			writer.WriteBytes (pdb_id_guid.ToByteArray ());
-			writer.WriteUInt32 (pdb_id_age);
+			writer.WriteUInt32 (pdb_id_stamp);
 		}
 	}
 

--- a/Test/Mono.Cecil.Tests/PortablePdbTests.cs
+++ b/Test/Mono.Cecil.Tests/PortablePdbTests.cs
@@ -886,7 +886,7 @@ class Program
 				GetPdbChecksumData (module.GetDebugHeader (), out string algorithmName, out byte [] checksum);
 				Assert.AreEqual ("SHA256", algorithmName);
 
-				string pdbPath = GetDebugHeaderPdbPath (module);
+				string pdbPath = Mixin.GetPdbFileName (module.FileName);
 				CalculatePdbChecksumAndId (pdbPath, out byte [] expectedChecksum, out byte [] pdbId);
 
 				CollectionAssert.AreEqual (expectedChecksum, checksum);
@@ -924,7 +924,7 @@ class Program
 				GetPdbChecksumData (module.GetDebugHeader (), out string algorithmName, out byte [] checksum);
 				Assert.AreEqual ("SHA256", algorithmName);
 
-				string pdbPath = GetDebugHeaderPdbPath (module);
+				string pdbPath = Mixin.GetPdbFileName (module.FileName);
 				CalculatePdbChecksumAndId (pdbPath, out byte [] expectedChecksum, out byte [] pdbId);
 
 				CollectionAssert.AreEqual (expectedChecksum, checksum);
@@ -961,7 +961,7 @@ class Program
 
 			byte [] pdbIdOne;
 			using (var module = ModuleDefinition.ReadModule (destination, new ReaderParameters { ReadSymbols = true })) {
-				string pdbPath = GetDebugHeaderPdbPath (module);
+				string pdbPath = Mixin.GetPdbFileName (module.FileName);
 				CalculatePdbChecksumAndId (pdbPath, out byte [] expectedChecksum, out pdbIdOne);
 			}
 
@@ -971,7 +971,7 @@ class Program
 
 			byte [] pdbIdTwo;
 			using (var module = ModuleDefinition.ReadModule (destination, new ReaderParameters { ReadSymbols = true })) {
-				string pdbPath = GetDebugHeaderPdbPath (module);
+				string pdbPath = Mixin.GetPdbFileName (module.FileName);
 				CalculatePdbChecksumAndId (pdbPath, out byte [] expectedChecksum, out pdbIdTwo);
 			}
 


### PR DESCRIPTION
Previous fix for deterministic PDB ID wrote the PDB stamp as the PDB Age field. This change fixes it to write the stamp as the stamp field of the CodeView header and writes the PDB Age as 1 always.

Added tests.

Also includes a test fix which was discovered by trying to merge the previous change into jbevain/cecil.