### PR TITLE
FieldRVA alignment mono/cecil tree

### DIFF
--- a/Mono.Cecil.Metadata/Buffers.cs
+++ b/Mono.Cecil.Metadata/Buffers.cs
@@ -256,17 +256,31 @@ namespace Mono.Cecil.Metadata {
 
 	sealed class DataBuffer : ByteBuffer {
 
+		int buffer_align = 4;
+
 		public DataBuffer ()
 			: base (0)
 		{
 		}
 
-		public RVA AddData (byte [] data)
+		void Align (int align)
 		{
+			align--;
+			WriteBytes (((position + align) & ~align) - position);
+		}
+
+		public RVA AddData (byte [] data, int align)
+		{
+			if (buffer_align < align)
+				buffer_align = align;
+
+			Align (align);
 			var rva = (RVA) position;
 			WriteBytes (data);
 			return rva;
 		}
+
+		public int BufferAlign => buffer_align;
 	}
 
 	abstract class HeapBuffer : ByteBuffer {

--- a/Mono.Cecil.Metadata/Buffers.cs
+++ b/Mono.Cecil.Metadata/Buffers.cs
@@ -266,6 +266,8 @@ namespace Mono.Cecil.Metadata {
 		void Align (int align)
 		{
 			align--;
+                        // Compute the number of bytes to align the current position.
+                        // Values of 0 will be written.
 			WriteBytes (((position + align) & ~align) - position);
 		}
 

--- a/Mono.Cecil.PE/ImageWriter.cs
+++ b/Mono.Cecil.PE/ImageWriter.cs
@@ -690,7 +690,7 @@ namespace Mono.Cecil.PE {
 
 			map.AddMap (TextSegment.Code, metadata.code.length, !pe64 ? 4 : 16);
 			map.AddMap (TextSegment.Resources, metadata.resources.length, 8);
-			map.AddMap (TextSegment.Data, metadata.data.length, 4);
+			map.AddMap (TextSegment.Data, metadata.data.length, metadata.data.BufferAlign);
 			if (metadata.data.length > 0)
 				metadata.table_heap.FixupData (map.GetRVA (TextSegment.Data));
 			map.AddMap (TextSegment.StrongNameSignature, GetStrongNameLength (), 4);

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1646,12 +1646,14 @@ namespace Mono.Cecil {
 
 			// To allow for safe implementation of metadata rewriters for code which uses CreateSpan<T>
 			// if the Field RVA refers to a locally defined type with a pack > 1, align the InitialValue
-			// to pack boundary.
+			// to pack boundary. This logic is restricted to only being affected by metadata local to the module
+			// as PackingSize is only used when examining a type local to the module being written.
 
 			int align = 1;
 			if (field.FieldType.IsDefinition && !field.FieldType.IsGenericInstance) {
 				var type = field.FieldType.Resolve ();
-				if (type.PackingSize > 1)
+
+				if ((type.Module == module) && (type.PackingSize > 1))
 					align = type.PackingSize;
 			}
 			table.AddRow (new FieldRVARow (

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -1643,8 +1643,19 @@ namespace Mono.Cecil {
 		void AddFieldRVA (FieldDefinition field)
 		{
 			var table = GetTable<FieldRVATable> (Table.FieldRVA);
+
+			// To allow for safe implementation of metadata rewriters for code which uses CreateSpan<T>
+			// if the Field RVA refers to a locally defined type with a pack > 1, align the InitialValue
+			// to pack boundary.
+
+			int align = 1;
+			if (field.FieldType.IsDefinition && !field.FieldType.IsGenericInstance) {
+				var type = field.FieldType.Resolve ();
+				if (type.PackingSize > 1)
+					align = type.PackingSize;
+			}
 			table.AddRow (new FieldRVARow (
-				data.AddData (field.InitialValue),
+				data.AddData (field.InitialValue, align),
 				field.token.RID));
 		}
 

--- a/Test/Resources/il/FieldRVAAlignment.il
+++ b/Test/Resources/il/FieldRVAAlignment.il
@@ -1,0 +1,71 @@
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly FieldRVAAlignment {}
+
+.module FieldRVAAlignment.dll
+
+.class private auto ansi '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'
+       extends [mscorlib]System.Object
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .class explicit ansi sealed nested private '__StaticArrayInitTypeSize=3'
+         extends [mscorlib]System.ValueType
+  {
+    .pack 1
+    .size 3
+  } // end of class '__StaticArrayInitTypeSize=3'
+
+  .class explicit ansi sealed nested private '__StaticArrayInitTypeSize=16'
+         extends [mscorlib]System.ValueType
+  {
+    .pack 8
+    .size 16
+  } // end of class '__StaticArrayInitTypeSize=16'
+
+  .class explicit ansi sealed nested private '__StaticArrayInitTypeSize=20'
+         extends [mscorlib]System.ValueType
+  {
+    .pack 4
+    .size 20
+  } // end of class '__StaticArrayInitTypeSize=20'
+
+  .class explicit ansi sealed nested private '__StaticArrayInitTypeSize=5'
+         extends [mscorlib]System.ValueType
+  {
+    .pack 1
+    .size 5
+  } // end of class '__StaticArrayInitTypeSize=5'
+
+  .class explicit ansi sealed nested private '__StaticArrayInitTypeSize=6'
+         extends [mscorlib]System.ValueType
+  {
+    .pack 2
+    .size 6
+  } // end of class '__StaticArrayInitTypeSize=6'
+
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=3' '$$method0x6000001-1' at I_000020F0
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=20' '$$method0x6000001-2' at I_000020F8
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=5' '$$method0x6000001-3' at I_00002108
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=20' '$$method0x6000001-4' at I_00002110
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=6' '$$method0x6000001-5' at I_00002120
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=16' '$$method0x6000001-6' at I_00002130
+} // end of class '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'
+
+
+// =============================================================
+
+.data cil I_000020F0 = bytearray (
+                 01 02 03)
+.data cil I_000020F8 = bytearray (
+                 01 00 00 00 02 00 00 00 03 00 00 00 04 00 00 00 05 00 00 00) 
+.data cil I_00002108 = bytearray (
+                 04 05 06 07 08)
+.data cil I_00002110 = bytearray (
+                 01 00 00 00 02 00 00 00 03 00 00 00 05 00 00 00 06 00 00 00) 
+.data cil I_00002120 = bytearray (
+                 08 00 0C 00 0D 00) 
+.data cil I_00002130 = bytearray (
+                 01 00 00 00 02 00 00 00 03 00 00 00 05 00 00 00) 


### PR DESCRIPTION
Port of PR jbevain/cecil#817 to mono/cecil tree

In support of dotnet/runtime#60948 the linker (an assembly rewriter) will need to be able to preserve the alignment of RVA based fields which are to be used to create the data for CreateSpan<T> records

This is implemented by adding a concept that RVA fields detect their required alignment by examining the PackingSize of the type of the field (if the field type is defined locally in the module)

This has been approved in the jbevain tree, but we need this sooner rather than later, so I've made a direct PR here as well.